### PR TITLE
Feature/add appclication rule for windows update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this module will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+# [1.0.0] - 2023-07-07
+
+Initial release of platform firewall rules
+
+## [1.1.0] - 2023-11-17
+
+### Added
+
+- application rule for windows update
+
+### Changed
+
+### Removed
+
+### Fixed
+
+- windows defender can find and download updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-# [1.0.0] - 2023-07-07
-
-Initial release of platform firewall rules
-
 ## [1.1.0] - 2023-11-17
 
 ### Added
@@ -24,3 +20,7 @@ Initial release of platform firewall rules
 ### Fixed
 
 - windows defender can find and download updates
+
+# [1.0.0] - 2023-07-07
+
+Initial release of platform firewall rules

--- a/main.tf
+++ b/main.tf
@@ -76,4 +76,24 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
       destination_ports     = ["80", "443"]
     }
   }
+
+  application_rule_collection {
+    name     = "rc-internet_outbound-${var.stage}"
+    priority = 130
+    action   = "allow"
+
+    rule {
+      name                  = "allow-update-management-outbound"
+      source_ip_groups      = [var.ipg_application_lz_id, var.ipg_platform_id]
+      destination_fqdn_tags = ["WindowsUpdate"]
+      protocols {
+        type = "Http"
+        port = 80
+      }
+      protocols {
+        type = "Https"
+        port = 443
+      }
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   }
 
   application_rule_collection {
-    name     = "rc-internet_outbound-${var.stage}"
+    name     = "rc-application_internet_outbound-${var.stage}"
     priority = 130
     action   = "Allow"
 

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   application_rule_collection {
     name     = "rc-internet_outbound-${var.stage}"
     priority = 130
-    action   = "allow"
+    action   = "Allow"
 
     rule {
       name                  = "allow-update-management-outbound"


### PR DESCRIPTION
# Description

Added application rule with FQDN tag WindowsUpdate to enable WindowsDefender to find updates

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `1.0.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `1.1.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Apply to a existing firewall was successful 

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
