### PR TITLE
new naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-09-03
+
+### Added
+- aligned Azure Firewall Policy Rule Collection names with the current Confluence naming convention by using the `rc-{type}-{LogicalName}-{status}` pattern for network and application rule collections
+
 ## [2.2.0] - 2025-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.3.0] - 2026-09-03
+## [3.0.0] - 2026-09-03
 
 ### Added
 - aligned Azure Firewall Policy Rule Collection names with the current Confluence naming convention by using the `rc-{type}-{LogicalName}-{status}` pattern for network and application rule collections

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   priority           = 100
 
   network_rule_collection {
-    name     = "rc-internet_outbound-${var.stage}"
+    name     = "rc-net-InternetOutbound-${var.stage}"
     priority = 100
     action   = "Allow"
 
@@ -55,7 +55,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   dynamic "network_rule_collection" {
     for_each = var.ipg_azure_dc_id == null ? [] : [var.ipg_azure_dc_id]
     content {
-      name     = "rc-DomainController-${var.stage}"
+      name     = "rc-net-DomainController-${var.stage}"
       priority = 105
       action   = "Allow"
 
@@ -72,7 +72,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   dynamic "network_rule_collection" {
     for_each = var.ipg_onpremise_dc_id != null && var.ipg_azure_dc_id != null ? [var.ipg_onpremise_dc_id] : []
     content {
-      name     = "rc-OnPremiseDC-${var.stage}"
+      name     = "rc-net-OnPremiseDC-${var.stage}"
       priority = 120
       action   = "Allow"
 
@@ -89,7 +89,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   dynamic "network_rule_collection" {
     for_each = var.ipg_dnsprivateresolver_id == null ? [] : [var.ipg_dnsprivateresolver_id]
     content {
-      name     = "rc-DNSPrivateResolver-${var.stage}"
+      name     = "rc-net-DNSPrivateResolver-${var.stage}"
       priority = 110
       action   = "Allow"
 
@@ -106,7 +106,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   dynamic "network_rule_collection" {
     for_each = var.bastion_config == null ? [] : [var.bastion_config.ipg_bastion_id]
     content {
-      name     = "rc-Bastion-${var.stage}"
+      name     = "rc-net-Bastion-${var.stage}"
       priority = 115
       action   = "Allow"
 
@@ -137,7 +137,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   }
 
   application_rule_collection {
-    name     = "rc-application_internet_outbound-${var.stage}"
+    name     = "rc-app-InternetOutbound-${var.stage}"
     priority = 150
     action   = "Allow"
 
@@ -193,7 +193,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   dynamic "application_rule_collection" {
     for_each = var.ipg_entra_connect_id == null ? [] : [var.ipg_entra_connect_id]
     content {
-      name     = "rc-application_entra_connect_outbound-${var.stage}"
+      name     = "rc-app-EntraConnectOutbound-${var.stage}"
       priority = 155
       action   = "Allow"
 


### PR DESCRIPTION
# Description

This PR aligns the Azure Firewall Policy Rule Collection naming in this module with the current naming convention defined in Confluence.

The rule collection names were updated to follow the documented format:

- `rc-{type}-{LogicalName}-{status}`

This affects both network and application rule collections in `main.tf`.

# Change overview (tick true):

- [x] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `v2.2.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `v3.0.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Apply of all examples was successfull
- [x] Naming conventions were checked against the Confluence HTML export

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
